### PR TITLE
Add support for Anthropic service and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@
 
 > Tips: 如果觉得好用或有使用的建议，欢迎去Github上 [**Start**](https://github.com/zdt1013/ai-git-commiter/stargazers)或 [**Issue**](https://github.com/zdt1013/ai-git-commiter/issues/)。
 
-> 截止此版本（v1.0.47）发布，双插件商店下载量已累计下载超过 **1000+** 次，正式收集2.x版本的需求，欢迎大家去[**Issue**](https://github.com/zdt1013/ai-git-commiter/issues/)提交反馈和需求。
+> 截止此版本（v1.0.48）发布，双插件商店下载量已累计下载超过 **1000+** 次，正式收集2.x版本的需求，欢迎大家去[**Issue**](https://github.com/zdt1013/ai-git-commiter/issues/)提交反馈和需求。
   <p align="center">
    <img src="docs/2025120201.png" alt="" width="400">
    <img src="docs/2025120202.png" alt="" width="335">
   </p>
 
 ## 🕑 更新历史
+- **v1.0.48**
+  * 新增：增加对Anthropic及兼容服务商的支持。
+
 - **v1.0.47**
   * 修复：修复命令面板中《AI生成Commit消息》命令在特定场景下的仓库识别异常问题。
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ai-git-commiter",
   "displayName": "AI Git Commiter",
   "description": "使用AI大模型自动生成Git Commit消息",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "publisher": "zdt1013",
   "repository": {
     "type": "git",
@@ -102,11 +102,13 @@
           "order": 2,
           "enum": [
             "OpenAI",
-            "Gemini"
+            "Gemini",
+            "Anthropic"
           ],
           "enumDescriptions": [
             "使用OpenAI或类OpenAI的API生成Commit消息",
-            "使用Google Gemini的API生成Commit消息"
+            "使用Google Gemini的API生成Commit消息",
+            "使用Anthropic或类Anthropic的API生成Commit消息（支持智谱等兼容服务商）"
           ],
           "description": "AI提供商"
         },
@@ -219,9 +221,56 @@
           "description": "Gemini模型最大输出长度",
           "when": "ai-git-commiter.provider == Gemini"
         },
-        "ai-git-commiter.git-diff.area": {
+        "ai-git-commiter.anthropic.baseUrl": {
           "type": "string",
           "order": 17,
+          "default": "https://open.bigmodel.cn/api/anthropic",
+          "description": "Anthropic API基础URL",
+          "when": "ai-git-commiter.provider == Anthropic"
+        },
+        "ai-git-commiter.anthropic.apiKey": {
+          "type": "string",
+          "order": 18,
+          "default": "",
+          "description": "Anthropic API密钥",
+          "when": "ai-git-commiter.provider == Anthropic"
+        },
+        "ai-git-commiter.anthropic.model": {
+          "type": "string",
+          "order": 19,
+          "default": "glm-5.1",
+          "description": "Anthropic模型名称",
+          "when": "ai-git-commiter.provider == Anthropic"
+        },
+        "ai-git-commiter.anthropic.temperature": {
+          "type": "number",
+          "order": 20,
+          "default": 0.7,
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Anthropic模型温度参数",
+          "when": "ai-git-commiter.provider == Anthropic"
+        },
+        "ai-git-commiter.anthropic.topP": {
+          "type": "number",
+          "order": 21,
+          "default": 1,
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Anthropic模型top_p参数",
+          "when": "ai-git-commiter.provider == Anthropic"
+        },
+        "ai-git-commiter.anthropic.maxTokens": {
+          "type": "number",
+          "order": 22,
+          "default": 500,
+          "minimum": 1,
+          "description": "Anthropic模型最大输出长度",
+          "when": "ai-git-commiter.provider == Anthropic"
+        },
+        "ai-git-commiter.git-diff.area": {
+          "type": "string",
+          "order": 23,
           "default": "auto",
           "enum": [
             "auto",
@@ -237,77 +286,77 @@
         },
         "ai-git-commiter.git-diff.wordDiff": {
           "type": "boolean",
-          "order": 18,
+          "order": 24,
           "default": true,
           "description": "显示单词级别的变更（而非整行），减少冗余内容"
         },
         "ai-git-commiter.git-diff.unified": {
           "type": "number",
-          "order": 19,
+          "order": 25,
           "default": 0,
           "minimum": 0,
           "description": "去除上下文行，仅保留实际变更"
         },
         "ai-git-commiter.git-diff.noColor": {
           "type": "boolean",
-          "order": 20,
+          "order": 26,
           "default": true,
           "description": "移除颜色代码，避免额外 Token 开销"
         },
         "ai-git-commiter.git-diff.diffFilter": {
           "type": "string",
-          "order": 21,
+          "order": 27,
           "default": "ACDMRT",
           "description": "过滤文件变更类型：A(添加)、C(复制)、D(删除)、M(修改)、R(重命名)、T(类型变更)"
         },
         "ai-git-commiter.git-diff.filterMeta": {
           "type": "boolean",
-          "order": 22,
+          "order": 28,
           "default": false,
           "description": "过滤掉冗余行（如 index、diff、Binary file 等元信息）"
         },
         "ai-git-commiter.git-diff.maxChanges": {
           "type": "number",
-          "order": 23,
+          "order": 29,
           "default": 500,
           "minimum": 1,
           "description": "AI生成建议最大变更行数，超过此值将提示用户减少暂存文件或手动输入"
         },
         "ai-git-commiter.prompt.selectedPromptTemplateId": {
           "type": "string",
-          "order": 24,
+          "order": 30,
           "default": "",
           "readonly": true,
           "description": "当前选中的提示词模板ID"
         },
         "ai-git-commiter.prompt.selectedTemplatePrompt": {
           "type": "string",
-          "order": 25,
+          "order": 31,
           "default": "",
           "readonly": true,
           "description": "当前选中的提示词模板内容"
         },
         "ai-git-commiter.prompt.languageAwareness": {
           "type": "string",
-          "order": 26,
+          "order": 32,
           "default": "",
           "description": "编程语言感知"
         },
         "ai-git-commiter.prompt.libraryAwareness": {
           "type": "string",
-          "order": 27,
+          "order": 33,
           "default": "",
           "description": "三方库感知"
         },
         "ai-git-commiter.prompt.enableLanguageAwareness": {
           "type": "boolean",
-          "order": 28,
+          "order": 34,
           "default": false,
           "description": "是否启用编程语言感知"
         },
         "ai-git-commiter.prompt.enableLibraryAwareness": {
           "type": "boolean",
-          "order": 29,
+          "order": 35,
           "default": false,
           "description": "是否启用三方库感知"
         }
@@ -341,6 +390,7 @@
     "vite": "^6.2.5"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@google/genai": "^0.8.0",
     "@types/xml2js": "^0.4.14",
     "axios": "^1.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.90.0
+        version: 0.90.0
       '@google/genai':
         specifier: ^0.8.0
         version: 0.8.0
@@ -72,6 +75,15 @@ importers:
 
 packages:
 
+  '@anthropic-ai/sdk@0.90.0':
+    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@azure/abort-controller@2.1.2':
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
@@ -115,6 +127,10 @@ packages:
   '@azure/msal-node@3.5.1':
     resolution: {integrity: sha512-dkgMYM5B6tI88r/oqf5bYd93WkenQpaWwiszJDk7avVjso8cmuKRTW97dA1RMi6RhihZFLtY1VtWxU9+sW2T5g==}
     engines: {node: '>=16'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.25.2':
     resolution: {integrity: sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==}
@@ -1278,6 +1294,10 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -1790,6 +1810,9 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -1995,6 +2018,10 @@ packages:
 
 snapshots:
 
+  '@anthropic-ai/sdk@0.90.0':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+
   '@azure/abort-controller@2.1.2':
     dependencies:
       tslib: 2.8.1
@@ -2070,6 +2097,8 @@ snapshots:
       '@azure/msal-common': 15.5.1
       jsonwebtoken: 9.0.2
       uuid: 8.3.2
+
+  '@babel/runtime@7.29.2': {}
 
   '@esbuild/aix-ppc64@0.25.2':
     optional: true
@@ -3250,6 +3279,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -3817,6 +3851,8 @@ snapshots:
       is-number: 7.0.0
 
   tr46@0.0.3: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@1.4.3(typescript@5.8.3):
     dependencies:

--- a/src/ai/ai-service.factory.ts
+++ b/src/ai/ai-service.factory.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { IAIService } from './ai-service.interface';
 import { OpenAIService } from './openai';
 import { GeminiService } from './gemini';
+import { AnthropicService } from './anthropic';
 import { CONFIG_CONSTANTS } from '../constants';
 
 export class AIServiceFactory {
@@ -21,6 +22,9 @@ export class AIServiceFactory {
                 break;
             case 'Gemini':
                 this.instance = GeminiService.getInstance();
+                break;
+            case 'Anthropic':
+                this.instance = AnthropicService.getInstance();
                 break;
             default:
                 throw new Error(`不支持的AI服务提供商: ${provider}`);

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -1,0 +1,110 @@
+import Anthropic from '@anthropic-ai/sdk';
+import * as vscode from 'vscode';
+import { PromptTemplate } from '../types/types';
+import { CONFIG_CONSTANTS } from '../constants';
+import { IAIService } from './ai-service.interface';
+import { AIModel } from '../types/model';
+
+export class AnthropicService implements IAIService {
+    private static instance: AnthropicService | null = null;
+    private anthropicClient: Anthropic | null = null;
+
+    private constructor() {
+    }
+
+    resetInstance(): void {
+        AnthropicService.instance = null;
+    }
+
+    public static getInstance(): AnthropicService {
+        if (AnthropicService.instance === null) {
+            AnthropicService.instance = new AnthropicService();
+        }
+        return AnthropicService.instance;
+    }
+
+    private getAnthropicClient(): Anthropic {
+        if (this.anthropicClient === null) {
+            const config = vscode.workspace.getConfiguration(CONFIG_CONSTANTS.ROOT);
+            const baseUrl = config.get<string>(CONFIG_CONSTANTS.ANTHROPIC.BASE_URL) || CONFIG_CONSTANTS.DEFAULTS.ANTHROPIC.BASE_URL;
+            const apiKey = config.get<string>(CONFIG_CONSTANTS.ANTHROPIC.API_KEY);
+
+            if (!apiKey) {
+                throw new Error('请在设置中配置Anthropic API密钥');
+            }
+
+            this.anthropicClient = new Anthropic({
+                apiKey: apiKey,
+                baseURL: baseUrl
+            });
+        }
+        return this.anthropicClient;
+    }
+
+    public async getAvailableModels(): Promise<AIModel[]> {
+        throw new Error('当前AI服务商不支持读取可用模型列表');
+    }
+
+    private async *callAnthropic(prompt: string, _promptTemplate: PromptTemplate): AsyncGenerator<string> {
+        const config = vscode.workspace.getConfiguration(CONFIG_CONSTANTS.ROOT);
+        const model = config.get<string>(CONFIG_CONSTANTS.ANTHROPIC.MODEL) || CONFIG_CONSTANTS.DEFAULTS.ANTHROPIC.MODEL;
+        const temperature = config.get<number>(CONFIG_CONSTANTS.ANTHROPIC.TEMPERATURE) ?? CONFIG_CONSTANTS.DEFAULTS.ANTHROPIC.TEMPERATURE;
+        const topP = config.get<number>(CONFIG_CONSTANTS.ANTHROPIC.TOP_P) ?? CONFIG_CONSTANTS.DEFAULTS.ANTHROPIC.TOP_P;
+        const maxTokens = config.get<number>(CONFIG_CONSTANTS.ANTHROPIC.MAX_TOKENS) ?? CONFIG_CONSTANTS.DEFAULTS.ANTHROPIC.MAX_TOKENS;
+
+        const client = this.getAnthropicClient();
+
+        try {
+            const stream = client.messages.stream({
+                model: model,
+                messages: [{ role: 'user', content: prompt }],
+                temperature: temperature,
+                top_p: topP,
+                max_tokens: maxTokens,
+            });
+
+            for await (const event of stream) {
+                if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+                    yield event.delta.text;
+                }
+            }
+        } catch (error: any) {
+            console.error('Anthropic API调用失败:', error);
+            throw new Error(`Anthropic API调用失败: ${error.message}`);
+        }
+    }
+
+    generateCommitMessage(diff: string, language: string, promptTemplate: PromptTemplate): AsyncGenerator<string> {
+        let prompt = promptTemplate.content
+            .replace('{diff}', diff)
+            .replaceAll('{language}', language);
+
+        const config = vscode.workspace.getConfiguration(CONFIG_CONSTANTS.ROOT);
+        const enableLanguageAwareness = config.get<boolean>(CONFIG_CONSTANTS.PROMPT.ENABLE_LANGUAGE_AWARENESS) ?? true;
+        const enableLibraryAwareness = config.get<boolean>(CONFIG_CONSTANTS.PROMPT.ENABLE_LIBRARY_AWARENESS) ?? true;
+
+        if (enableLanguageAwareness && promptTemplate.preferredLanguages?.length) {
+            const prefix = promptTemplate.preferredLanguagePrompt || '项目主要使用的编程语言：';
+            prompt = prompt.replace('{preferredLanguages}', `\n${prefix}${promptTemplate.preferredLanguages.join(', ')}`);
+        } else {
+            prompt = prompt.replace('{preferredLanguages}', '');
+        }
+
+        if (enableLibraryAwareness && promptTemplate.preferredLibraries?.length) {
+            const prefix = promptTemplate.preferredLibraryPrompt || '项目主要使用的三方库：';
+            prompt = prompt.replace('{preferredLibraries}', `\n${prefix}${promptTemplate.preferredLibraries.join(', ')}`);
+        } else {
+            prompt = prompt.replace('{preferredLibraries}', '');
+        }
+
+        return this.callAnthropic(prompt, promptTemplate);
+    }
+
+    polishCommitMessage(message: string, language: string, promptTemplate: PromptTemplate): AsyncGenerator<string> {
+        let prompt = promptTemplate.polishContent
+            .replace('{diff}', message)
+            .replaceAll('{language}', language);
+
+        return this.callAnthropic(prompt, promptTemplate);
+    }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,11 @@ export class ConfigService {
             gemini: {
                 apiKey: config.get<string>(CONFIG_CONSTANTS.GEMINI.API_KEY) || ''
             },
+            anthropic: {
+                apiKey: config.get<string>(CONFIG_CONSTANTS.ANTHROPIC.API_KEY) || '',
+                model: config.get<string>(CONFIG_CONSTANTS.ANTHROPIC.MODEL) || CONFIG_CONSTANTS.DEFAULTS.ANTHROPIC.MODEL,
+                baseUrl: config.get<string>(CONFIG_CONSTANTS.ANTHROPIC.BASE_URL) || CONFIG_CONSTANTS.DEFAULTS.ANTHROPIC.BASE_URL
+            },
             git: {
                 diff: {
                     wordDiff: config.get<boolean>(CONFIG_CONSTANTS.GIT.DIFF.WORD_DIFF) ?? CONFIG_CONSTANTS.DEFAULTS.GIT.DIFF.WORD_DIFF,
@@ -112,6 +117,20 @@ export class ConfigService {
             if (!apiKey) {
                 const result = await vscode.window.showWarningMessage(
                     'Gemini配置不完整，是否立即配置？',
+                    { modal: true },
+                    '配置',
+                );
+
+                if (result === '配置') {
+                    await vscode.commands.executeCommand('workbench.action.openSettings', CONFIG_CONSTANTS.ROOT);
+                }
+                return false;
+            }
+        } else if (provider === CONFIG_CONSTANTS.PROVIDERS.ANTHROPIC) {
+            const { apiKey, model, baseUrl } = config.anthropic;
+            if (!baseUrl || !apiKey || !model) {
+                const result = await vscode.window.showWarningMessage(
+                    'Anthropic配置不完整，是否立即配置？',
                     { modal: true },
                     '配置',
                 );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -195,6 +195,16 @@ export const CONFIG_CONSTANTS = {
         BASE_URL: 'gemini.baseUrl'
     },
 
+    // Anthropic配置
+    ANTHROPIC: {
+        BASE_URL: 'anthropic.baseUrl',
+        API_KEY: 'anthropic.apiKey',
+        MODEL: 'anthropic.model',
+        TEMPERATURE: 'anthropic.temperature',
+        TOP_P: 'anthropic.topP',
+        MAX_TOKENS: 'anthropic.maxTokens'
+    },
+
     // 默认值
     DEFAULTS: {
         PROVIDER: 'OpenAI',
@@ -214,6 +224,13 @@ export const CONFIG_CONSTANTS = {
             MAX_OUTPUT_TOKENS: 500,
             BASE_URL: 'https://generativelanguage.googleapis.com'
         },
+        ANTHROPIC: {
+            BASE_URL: 'https://open.bigmodel.cn/api/anthropic',
+            MODEL: 'glm-5.1',
+            TEMPERATURE: 0.7,
+            TOP_P: 1,
+            MAX_TOKENS: 500
+        },
         GIT: {
             DIFF: {
                 MAX_CHANGES: 100,
@@ -231,7 +248,8 @@ export const CONFIG_CONSTANTS = {
     // AI提供商
     PROVIDERS: {
         OPENAI: 'OpenAI',
-        GEMINI: 'Gemini'
+        GEMINI: 'Gemini',
+        ANTHROPIC: 'Anthropic'
     },
     LANGUAGE: "language"
 }; 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -28,6 +28,15 @@ export interface GeminiConfig {
 }
 
 /**
+ * Anthropic配置
+ */
+export interface AnthropicConfig {
+    apiKey: string;
+    model: string;
+    baseUrl: string;
+}
+
+/**
  * 扩展配置
  */
 export interface ExtensionConfig {
@@ -35,6 +44,7 @@ export interface ExtensionConfig {
     language: string;
     openai: OpenAIConfig;
     gemini: GeminiConfig;
+    anthropic: AnthropicConfig;
     git: {
         diff: GitDiffConfig;
     };


### PR DESCRIPTION
✨ feat(config): 增加对Anthropic及兼容服务商的支持

- 新增Anthropic服务提供商选项。
- 添加Anthropic API的配置项，包括基础URL、API密钥、模型名称及相关参数。
- 实现Anthropic配置缺失时的提示与引导逻辑。
- 在AI服务工厂中集成Anthropic服务实例的创建。

📦 build(deps): 引入Anthropic SDK及相关依赖

- 添加`@anthropic-ai/sdk`库及其相关依赖到项目。
