### PR TITLE
✨ feat(config): 增加自定义User-Agent配置功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ai-git-commiter",
   "displayName": "AI Git Commiter",
   "description": "使用AI大模型自动生成Git Commit消息",
-  "version": "1.0.48",
+  "version": "1.0.51",
   "publisher": "zdt1013",
   "repository": {
     "type": "git",
@@ -117,6 +117,12 @@
           "default": false,
           "order": 3,
           "description": "是否启用推理"
+        },
+        "ai-git-commiter.userAgent": {
+          "type": "string",
+          "order": 3.5,
+          "default": "",
+          "description": "自定义请求User-Agent，留空则使用SDK默认。部分模型服务商可能会限制默认User-Agent导致请求被拒绝。"
         },
         "ai-git-commiter.openai.baseUrl": {
           "type": "string",

--- a/src/ai/anthropic.ts
+++ b/src/ai/anthropic.ts
@@ -33,10 +33,17 @@ export class AnthropicService implements IAIService {
                 throw new Error('请在设置中配置Anthropic API密钥');
             }
 
-            this.anthropicClient = new Anthropic({
+            const userAgent = config.get<string>(CONFIG_CONSTANTS.USER_AGENT) || '';
+            const clientConfig: Anthropic.ClientOptions = {
                 apiKey: apiKey,
                 baseURL: baseUrl
-            });
+            };
+            if (userAgent) {
+                clientConfig.defaultHeaders = {
+                    'User-Agent': userAgent
+                };
+            }
+            this.anthropicClient = new Anthropic(clientConfig);
         }
         return this.anthropicClient;
     }

--- a/src/ai/openai.ts
+++ b/src/ai/openai.ts
@@ -39,10 +39,17 @@ export class OpenAIService implements IAIService {
                 throw new Error('请在设置中配置OpenAI API密钥');
             }
 
-            this.openaiClient = new OpenAI({
+            const userAgent = config.get<string>(CONFIG_CONSTANTS.USER_AGENT) || '';
+            const clientConfig: OpenAI.ClientOptions = {
                 apiKey: apiKey,
                 baseURL: baseUrl
-            });
+            };
+            if (userAgent) {
+                clientConfig.defaultHeaders = {
+                    'User-Agent': userAgent
+                };
+            }
+            this.openaiClient = new OpenAI(clientConfig);
         }
         return this.openaiClient;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ export class ConfigService {
         return {
             provider: config.get<string>('provider') || CONFIG_CONSTANTS.PROVIDERS.OPENAI,
             language: config.get<string>(CONFIG_CONSTANTS.LANGUAGE) || CONFIG_CONSTANTS.DEFAULTS.LANGUAGE,
+            userAgent: config.get<string>(CONFIG_CONSTANTS.USER_AGENT) || '',
             openai: {
                 apiKey: config.get<string>(CONFIG_CONSTANTS.OPENAI.API_KEY) || '',
                 model: config.get<string>(CONFIG_CONSTANTS.OPENAI.MODEL) || CONFIG_CONSTANTS.DEFAULTS.OPENAI.MODEL,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -150,6 +150,7 @@ export const CONFIG_CONSTANTS = {
 
     // 通用配置
     ENABLE_THINKING: 'enable_thinking',
+    USER_AGENT: 'userAgent',
 
     // 提示词配置
     PROMPT: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -42,6 +42,7 @@ export interface AnthropicConfig {
 export interface ExtensionConfig {
     provider: string;
     language: string;
+    userAgent: string;
     openai: OpenAIConfig;
     gemini: GeminiConfig;
     anthropic: AnthropicConfig;


### PR DESCRIPTION
## 功能说明

支持用户在 VS Code 设置中自定义 HTTP 请求的 User-Agent，解决部分大模型接口因限制默认 User-Agent 而导致请求被拒绝的问题。

## 修改内容

| 文件 | 修改说明 |
|------|---------|
| `package.json` | 新增 `ai-git-commiter.userAgent` 设置项 |
| `src/constants.ts` | 新增 `USER_AGENT` 常量 |
| `src/types/config.ts` | `ExtensionConfig` 接口新增 `userAgent` 字段 |
| `src/config.ts` | `getExtensionConfig()` 中读取 userAgent 配置 |
| `src/ai/openai.ts` | 创建 OpenAI 客户端时通过 `defaultHeaders` 传入自定义 `User-Agent` |
| `src/ai/anthropic.ts` | 创建 Anthropic 客户端时通过 `defaultHeaders` 传入自定义 `User-Agent` |

## 使用方式

在 VS Code 设置中填写 `ai-git-commiter.userAgent`，例如：

claude-cli/2.1.109 (external, cli)

留空则使用 SDK 默认行为，不影响现有用户。

## 兼容性

该配置对 **OpenAI** 和 **Anthropic** 两种协议均生效，Gemini 协议不受影响（其 SDK 不暴露 `User-Agent` 配置）。